### PR TITLE
Add LVPI CI/CD workflow with GitHub OIDC

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+# Build-time environment variables for SvelteKit
+# Real values are loaded at runtime from S3 via entrypoint.sh
+
+# Required for SvelteKit build ($env/static/private imports)
+CACHE_TYPE='in-memory'
+CACHE_HOST='localhost'
+CACHE_PASSWORD=''
+
+# Placeholder URLs (overridden at runtime)
+BACKEND_API_URL='https://placeholder-api.example.com/api/v1'
+API_CLIENT_INTERNAL_KEY='build-placeholder-key'

--- a/.github/LVPEI_DEPLOYMENT.md
+++ b/.github/LVPEI_DEPLOYMENT.md
@@ -1,0 +1,1 @@
+# Trigger build for LVPEI deployment - Mon Dec 29 20:02:43 IST 2025

--- a/.github/LVPEI_PROD_DEPLOYMENT.md
+++ b/.github/LVPEI_PROD_DEPLOYMENT.md
@@ -1,0 +1,1 @@
+LVPEI Production Deployment - Mon Dec 29 20:33:30 IST 2025

--- a/.github/workflows/lvpi-ci-cd.yml
+++ b/.github/workflows/lvpi-ci-cd.yml
@@ -5,7 +5,7 @@ name: LVPI-CI-CD
 
 on:
   push:
-    branches: [main]
+    branches: [main, feature/lvpi-ci-cd]
   workflow_dispatch:
     inputs:
       deploy_to_ecs:

--- a/.github/workflows/lvpi-ci-cd.yml
+++ b/.github/workflows/lvpi-ci-cd.yml
@@ -58,6 +58,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      # Download configuration files from S3 before build
+      # These files contain real values that will be embedded during npm run build
+      - name: Copy env file from S3
+        run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/.env ./.env
+
+      - name: Copy constants file from S3
+        run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/constants.ts ./src/lib/constants.ts
+
+      - name: Copy favicon file from S3
+        run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/favicon.png ./static/favicon.png
+
       - name: Build and push Docker image
         id: build-image
         env:

--- a/.github/workflows/lvpi-ci-cd.yml
+++ b/.github/workflows/lvpi-ci-cd.yml
@@ -1,0 +1,83 @@
+# LVPI Production CI/CD Pipeline
+# Uses OIDC for secure, keyless authentication to AWS
+
+name: LVPI-CI-CD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deploy_to_ecs:
+        description: 'Deploy to ECS after building'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  AWS_REGION: ap-south-2
+  ECR_REPOSITORY: lvpi-prod-patient-portal
+  IMAGE_TAG: ${{ github.sha }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+    environment: lvpi-prod
+
+    outputs:
+      image_uri: ${{ steps.build-image.outputs.image_uri }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::777184858387:role/lvpi-prod-github-actions-role
+          role-session-name: GitHubActions-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and push Docker image
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --push \
+            --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            .
+
+          echo "image_uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Image digest
+        run: |
+          echo "Image pushed: ${{ steps.build-image.outputs.image_uri }}"

--- a/.github/workflows/lvpi-ci-cd.yml
+++ b/.github/workflows/lvpi-ci-cd.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   AWS_REGION: ap-south-2
-  ECR_REPOSITORY: lvpi-prod-patient-portal
+  ECR_REPOSITORY: lvpei-prod-patient-portal
   IMAGE_TAG: ${{ github.sha }}
 
 permissions:
@@ -39,7 +39,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::777184858387:role/lvpi-prod-github-actions-role
+          role-to-assume: arn:aws:iam::777184858387:role/lvpei-prod-github-actions-role
           role-session-name: GitHubActions-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/lvpi-ci-cd.yml
+++ b/.github/workflows/lvpi-ci-cd.yml
@@ -11,7 +11,7 @@ on:
       deploy_to_ecs:
         description: 'Deploy to ECS after building'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 env:
@@ -58,16 +58,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      # Download configuration files from S3 before build
-      # These files contain real values that will be embedded during npm run build
+      # Download .env from S3 before build
+      # Contains real values that will be embedded during npm run build via $env/static/private
+      # Note: constants.ts and favicon.png are downloaded at RUNTIME by entrypoint.sh
       - name: Copy env file from S3
         run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/.env ./.env
-
-      - name: Copy constants file from S3
-        run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/constants.ts ./src/lib/constants.ts
-
-      - name: Copy favicon file from S3
-        run: aws s3 cp s3://${{ secrets.LVPEI_CONFIG_BUCKET }}/patient-portal/favicon.png ./static/favicon.png
 
       - name: Build and push Docker image
         id: build-image


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for LVPI production deployment (ap-south-2)
- Use OIDC for secure, keyless AWS authentication
- Build and push Docker images to ECR

## Details
- **Target ECR**: `777184858387.dkr.ecr.ap-south-2.amazonaws.com/lvpi-prod-patient-portal`
- **IAM Role**: `arn:aws:iam::777184858387:role/lvpi-prod-github-actions-role`
- **Triggers**: Push to main branch or manual workflow dispatch

## Test plan
- [ ] Merge PR to activate workflow
- [ ] Manually trigger workflow to test OIDC authentication
- [ ] Confirm image is pushed to ECR